### PR TITLE
Use a strict CSP for texen

### DIFF
--- a/src/content/texen/.htaccess
+++ b/src/content/texen/.htaccess
@@ -1,0 +1,1 @@
+Header set Content-Security-Policy "default-src 'self'"


### PR DESCRIPTION
As this component is archived and not updated anymore

Not tested since `./builder/bin/builder.sh` serves the pages with Python and thus does not support `.htaccess`.